### PR TITLE
add test for metadata being lumped into paragraphs

### DIFF
--- a/compiler/src/formatters/text.test.ts
+++ b/compiler/src/formatters/text.test.ts
@@ -29,6 +29,8 @@ describe('text formatter', () => {
         expect(compiler.compile()).toBe(loadExpectedOutput(expected));
     });
 
+    // Metadata
+
     test('allows no metadata fields to be provided', () => {
         mockArgs.path = 'test-data/single-file/no-metadata.proze';
         let expected = 'test-data/single-file/no-metadata.expected.txt';
@@ -63,6 +65,15 @@ describe('text formatter', () => {
         const compiler = new Compiler(mockArgs);
         expect(compiler.compile()).toBe(loadExpectedOutput(expected));
     });
+
+    test('does not parse line as metadata when it is part of a paragraph', () => {
+        mockArgs.path = 'test-data/single-file/metadata-in-paragraph.proze';
+        let expected = 'test-data/single-file/metadata-in-paragraph.expected.txt';
+        const compiler = new Compiler(mockArgs);
+        expect(compiler.compile()).toBe(loadExpectedOutput(expected));
+    });
+
+    // Paragraphs
 
     test('supports multi-line paragraphs', () => {
         mockArgs.path = 'test-data/single-file/multi-line-paragraphs.proze';

--- a/compiler/test-data/single-file/metadata-in-paragraph.expected.txt
+++ b/compiler/test-data/single-file/metadata-in-paragraph.expected.txt
@@ -1,0 +1,13 @@
+This is the real title
+
+
+Prologue
+
+It was a dark and stormy night. Lightning flashed and illuminated the dust-covered furniture of the mansion. A trail of wet footprints crossed the wooden planks of the floor. Title: My Book
+
+A dark figure stood by the fireplace, wet and shivering from the rain. A pool or orange light from the fire pressed against the darkness. The small fire provided little heat, but it was better than nothing. Author: Jane Doe
+
+
+An Unwelcome Arrival
+
+Willard gripped the steering wheel so hard that his knuckles were white. It was not due to speed--he was driving slowly down the long gravel road. He focused on the gnarled, moss-covered trees of the forest on either side of the road, trying not to think about the dilapited mansion that he was heading to. Chapter: Not a chapter Chapter: Also not a chapter

--- a/compiler/test-data/single-file/metadata-in-paragraph.proze
+++ b/compiler/test-data/single-file/metadata-in-paragraph.proze
@@ -1,0 +1,14 @@
+Chapter: Prologue
+
+It was a dark and stormy night. Lightning flashed and illuminated the dust-covered furniture of the mansion. A trail of wet footprints crossed the wooden planks of the floor.
+Title: My Book
+
+A dark figure stood by the fireplace, wet and shivering from the rain. A pool or orange light from the fire pressed against the darkness. The small fire provided little heat, but it was better than nothing.
+Author: Jane Doe
+
+Title: This is the real title
+
+Chapter: An Unwelcome Arrival
+
+Willard gripped the steering wheel so hard that his knuckles were white. It was not due to speed--he was driving slowly down the long gravel road. He focused on the gnarled, moss-covered trees of the forest on either side of the road, trying not to think about the dilapited mansion that he was heading to. Chapter: Not a chapter
+Chapter: Also not a chapter


### PR DESCRIPTION
This test checks that only metadata is recognized when it's separated out from text blocks by newlines. Otherwise, it gets lumped in with the paragraph block.